### PR TITLE
docs: fix markdown rendering

### DIFF
--- a/_docs/concepts/what-is-grafeas/overview.md
+++ b/_docs/concepts/what-is-grafeas/overview.md
@@ -71,8 +71,8 @@ timestamp. Where possible, use content-addressable resource URLs.
 The following table provides examples of possible resource URLs for several
 component types:
 
-Component Type | Identifier                               | Example
--------------- | ---------------------------------------- | -------
+Component Type | Identifier                                 | Example
+:---           | :---                                       | :---
 Debian         | `deb://dist(optional):arch:name:version`   | `deb://lucid:i386:acl:2.2.49-2`
 Docker         | `https://Namespace/name@sha256:<Checksum>` | `https://gcr.io/scanning-customer/dockerimage@sha256:244fd47e07d1004f0aed9c156aa09083c82bf8944eceb67c946ff7430510a77b`
 Generic file   | `file://sha256:<Checksum>:name`            | `file://sha256:244fd47e07d1004f0aed9c156aa09083c82bf8944eceb67c946ff7430510a77b:foo.jar`

--- a/_docs/concepts/what-is-grafeas/overview.md
+++ b/_docs/concepts/what-is-grafeas/overview.md
@@ -73,14 +73,14 @@ component types:
 
 Component Type | Identifier                               | Example
 -------------- | ---------------------------------------- | -------
-Debian         | deb://dist(optional):arch:name:version   | deb://lucid:i386:acl:2.2.49-2
-Docker         | https://Namespace/name@sha256:<Checksum> | https://gcr.io/scanning-customer/dockerimage@sha256:244fd47e07d1004f0aed9c156aa09083c82bf8944eceb67c946ff7430510a77b
-Generic file   | file://sha256:<Checksum>:name            | file://sha256:244fd47e07d1004f0aed9c156aa09083c82bf8944eceb67c946ff7430510a77b:foo.jar
-Maven          | gav://group:artifact:version             | `gav://ant:ant:1.6.5`
-NPM            | npm://package:version                    | npm://mocha:2.4.5
-NuGet          | nuget://module:version                   | nuget://log4net:9.0.1
-Python         | pip://package:version                    | pip://raven:5.13.0
-RPM            | rpm://dist(optional):arch:name:version   | rpm://el6:i386:ImageMagick:6.7.2.7-4
+Debian         | `deb://dist(optional):arch:name:version`   | `deb://lucid:i386:acl:2.2.49-2`
+Docker         | `https://Namespace/name@sha256:<Checksum>` | `https://gcr.io/scanning-customer/dockerimage@sha256:244fd47e07d1004f0aed9c156aa09083c82bf8944eceb67c946ff7430510a77b`
+Generic file   | `file://sha256:<Checksum>:name`            | `file://sha256:244fd47e07d1004f0aed9c156aa09083c82bf8944eceb67c946ff7430510a77b:foo.jar`
+Maven          | `gav://group:artifact:version`             | `gav://ant:ant:1.6.5`
+NPM            | `npm://package:version`                    | `npm://mocha:2.4.5`
+NuGet          | `nuget://module:version`                   | `nuget://log4net:9.0.1`
+Python         | `pip://package:version`                    | `pip://raven:5.13.0`
+RPM            | `rpm://dist(optional):arch:name:version`   | `rpm://el6:i386:ImageMagick:6.7.2.7-4`
 
 ## Kind-Specific Schemas
 


### PR DESCRIPTION
This is also fixable by changing `<Checksum>` to `checksum` and avoiding markdown code blocks, although code blocks are clearer IMHO.

Also fixed in Grafeas repo https://github.com/grafeas/grafeas/pull/234